### PR TITLE
Add URL prefix 'api/v1' to REST API

### DIFF
--- a/src/main/java/de/samples/quarkus/todos/rest/TodosApplication.java
+++ b/src/main/java/de/samples/quarkus/todos/rest/TodosApplication.java
@@ -1,0 +1,9 @@
+package de.samples.quarkus.todos.rest;
+
+import javax.ws.rs.ApplicationPath;
+import javax.ws.rs.core.Application;
+
+@ApplicationPath("api/v1")
+public class TodosApplication extends Application {
+
+}


### PR DESCRIPTION
The URL changes from 

```
http://localhost:8080/todos
```

to

```
http://localhost:8080/api/v1/todos
```

Why?
 - `api` is a common prefix for REST APIs
 - `v1` is the major version and allows to run a new (incompatible) version under `v2` in parallel