### PR TITLE
Add 404 Status Code in case Todo cannot be found

### DIFF
--- a/src/main/java/de/samples/quarkus/todos/rest/NotFoundException.java
+++ b/src/main/java/de/samples/quarkus/todos/rest/NotFoundException.java
@@ -1,0 +1,7 @@
+package de.samples.quarkus.todos.rest;
+
+public class NotFoundException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+}

--- a/src/main/java/de/samples/quarkus/todos/rest/NotFoundExceptionMapper.java
+++ b/src/main/java/de/samples/quarkus/todos/rest/NotFoundExceptionMapper.java
@@ -1,0 +1,16 @@
+package de.samples.quarkus.todos.rest;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+@Provider
+public class NotFoundExceptionMapper implements ExceptionMapper<NotFoundException> {
+
+    @Override
+    public Response toResponse(NotFoundException exception) {
+        return Response.status(Status.NOT_FOUND).build();
+    }
+
+}

--- a/src/main/java/de/samples/quarkus/todos/rest/TodosResource.java
+++ b/src/main/java/de/samples/quarkus/todos/rest/TodosResource.java
@@ -2,6 +2,7 @@ package de.samples.quarkus.todos.rest;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Optional;
 import java.util.TreeMap;
 
 import javax.ws.rs.Consumes;
@@ -29,7 +30,15 @@ public class TodosResource {
 	@GET
 	@Path("/{id}")
 	public Todo findById(@PathParam("id") Long id) {
-		return todos.get(id); // TODO 404?
+		var result = todos.get(id);
+		if(null == result) {
+			throw new NotFoundException();
+		} else {
+			return result;
+		}
+		// alternativ:
+		// return Optional.ofNullable(todos.get(id))
+		//		.orElseThrow(NotFoundException::new);
 	}
 
 	@POST


### PR DESCRIPTION
Principle:
 - we throw an exception within the Resource
 - we implement a JAX-RS Exception Mapper that catches the exception and returns a 404 status code
 - this is global (valid for all Resources)
 - we could directly throw a WebApplicationException instead, like shown [here](https://dennis-xlc.gitbooks.io/restful-java-with-jax-rs-2-0-2rd-edition/content/en/part1/chapter7/exception_handling.html)