### PR TITLE
Add OpenAPI and Swagger UI

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,10 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>io.quarkus</groupId>
+			<artifactId>quarkus-smallrye-openapi</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>io.rest-assured</groupId>
 			<artifactId>rest-assured</artifactId>
 			<scope>test</scope>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+quarkus.smallrye-openapi.path=/openapi


### PR DESCRIPTION
- OpenAPI is available under [http://localhost:8080/openapi](http://localhost:8080/openapi)
- Swagger UI is available under [http://localhost:8080/q/swagger-ui/](http://localhost:8080/q/swagger-ui/) (only in dev mode)